### PR TITLE
Update runtime to gnome 44 and update submodules

### DIFF
--- a/org.gnome.SoundJuicer.json
+++ b/org.gnome.SoundJuicer.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.SoundJuicer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "sound-juicer",
     "finish-args": [


### PR DESCRIPTION
```
flatpak run --command=`pwd`/check-necessary-plugins.sh --filesystem=`pwd` org.gnome.SoundJuicer
```
didn't show any errors (exit code 0) and I ripped one track of a CD in each output format.

Closes #9