### PR TITLE
Use taglib from the runtime

### DIFF
--- a/org.gnome.SoundJuicer.json
+++ b/org.gnome.SoundJuicer.json
@@ -67,38 +67,6 @@
                 }
             ]
         },
-        /* utfcpp is required by taglib */
-        {
-            "name": "utfcpp",
-            "buildsystem": "cmake",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/nemtrif/utfcpp.git",
-                    "tag": "v4.0.9",
-                    "commit": "63d64de49fd6b829f7c8694df5ab2ee625cb7134"
-                }
-            ]
-        },
-        /* To encode in MP3 */
-        {
-          "name": "taglib",
-          "buildsystem": "cmake-ninja",
-          "config-opts": [
-            "-DBUILD_SHARED_LIBS=ON"
-          ],
-          "cleanup": [
-            "/include",
-            "/lib/*.so"
-          ],
-          "sources": [
-            {
-              "type": "archive",
-              "url": "https://github.com/taglib/taglib/releases/download/v2.0.1/taglib-2.0.1.tar.gz",
-              "sha256": "08c0a27b96aa5c4e23060fe0b6f93102ee9091a9385257b9d0ddcf467de0d925"
-            }
-         ]
-        },
         /* To play cdda */
         {
             "name": "gstreamer",


### PR DESCRIPTION
taglib is now available in the runtime.

Closes: https://github.com/flathub/org.gnome.SoundJuicer/issues/17